### PR TITLE
Migrated to Python 3.11.6. Could not use 3.12 because of some dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
+scipy
 tabulate
 scikit-image
-imagecodecs
 matplotlib
 PyQt5
 pyinstaller


### PR DESCRIPTION
- Migrated to Python 3.11.6. Could not use 3.12 because of some dependencies.  